### PR TITLE
Redraw and escaping problem fixed

### DIFF
--- a/autoload/phpsearch.vim
+++ b/autoload/phpsearch.vim
@@ -1,8 +1,8 @@
 function! phpsearch#doc(type, keyword)
   if a:type == 'function'
-    let url = 'http://php.net/manual/en/function.'.a:keyword.'.php'
+    let url = 'http://php.net/manual/en/function.' . a:keyword . '.php'
   else
-    let url = 'http://php.net/results.php?q='.a:keyword.'&p='.a:type.'&l=en'
+    let url = 'http://php.net/results.php?q=' . a:keyword . '&p=' . a:type . '&l=en'
   endif
 
   silent exec '!' . g:php_search_doc_command . ' "' . url . '" &'


### PR DESCRIPTION
- Missing `:redraw` added if vim is running in the "non gui" mode
- The url is now wrapped within `"` 
  - Urls with spaces are possible
  - We avoid errors with the `&` in the url
- `exec :silent !...` replaced with the more readable `silent exec !...`
