### PR TITLE
Allow functionnames with "_"

### DIFF
--- a/autoload/phpsearch.vim
+++ b/autoload/phpsearch.vim
@@ -1,8 +1,10 @@
 function! phpsearch#doc(type, keyword)
+  let keyword = substitute(a:keyword, '_', '-', 'g')
+
   if a:type == 'function'
-    let url = 'http://php.net/manual/en/function.' . a:keyword . '.php'
+    let url = 'http://php.net/manual/en/function.' . keyword . '.php'
   else
-    let url = 'http://php.net/results.php?q=' . a:keyword . '&p=' . a:type . '&l=en'
+    let url = 'http://php.net/results.php?q=' . keyword . '&p=' . a:type . '&l=en'
   endif
 
   silent exec '!' . g:php_search_doc_command . ' "' . url . '" &'


### PR DESCRIPTION
We have to replace "_" with "-" in the URL or the lookup will fail 
and we end on the "404 Not Found" page.
